### PR TITLE
New optional param customDateUtc to configure epoch of TSID Factory

### DIFF
--- a/src/TsidFactory.php
+++ b/src/TsidFactory.php
@@ -39,7 +39,7 @@ final class TsidFactory implements TsidFactoryInterface
 
     private int $customEpoch;
 
-    public function __construct(int $nodeBits = self::NODE_BITS_1024, int $node = null, DateTimeImmutable $customDateUtc = null)
+    public function __construct(int $nodeBits = self::NODE_BITS_1024, ?int $node = null, ?DateTimeImmutable $customDateUtc = null)
     {
         $this->nodeBits = $nodeBits;
 

--- a/src/TsidFactory.php
+++ b/src/TsidFactory.php
@@ -39,12 +39,12 @@ final class TsidFactory implements TsidFactoryInterface
 
     private int $customEpoch;
 
-    public function __construct(int $nodeBits = self::NODE_BITS_1024, int $node = null)
+    public function __construct(int $nodeBits = self::NODE_BITS_1024, int $node = null, DateTimeImmutable $customDateUtc = null)
     {
         $this->nodeBits = $nodeBits;
 
-        // Number of milliseconds of 2020-01-01T00:00:00.000Z.
-        $dateUtc = new DateTimeImmutable('2020-01-01T00:00:00.000Z', new DateTimeZone('UTC'));
+        // Number of milliseconds of 2020-01-01T00:00:00.000Z or custom date time.
+        $dateUtc = $customDateUtc ?: new DateTimeImmutable('2020-01-01T00:00:00.000Z', new DateTimeZone('UTC'));
         $this->customEpoch = (int)substr($dateUtc->format('Uu'), 0, 13);
 
         // setup constants that depend on node bits


### PR DESCRIPTION
I am submitting a PR with unit test to add optional parameter to change epoch of TSID Factory.